### PR TITLE
feat(usage): record streaming /chat/completions (Task #8)

### DIFF
--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -10,8 +10,11 @@ import { checkRateLimit } from "~/lib/rate-limit"
 import { state } from "~/lib/state"
 import { getTokenCount } from "~/lib/tokenizer"
 import {
+  createOpenAIAccumulator,
   normalizeOpenAIFinal,
+  UsageMissingError,
   type NormalizedUsage,
+  type StreamUsageAccumulator,
 } from "~/lib/usage-normalizer"
 import { recordUsage } from "~/lib/usage-recorder"
 import { isNullish, makeApiContext, resolveAndMapModelId } from "~/lib/utils"
@@ -28,6 +31,92 @@ const ZERO_USAGE: NormalizedUsage = {
   outputTokens: 0,
   reasoningTokens: 0,
   totalTokens: 0,
+}
+
+interface RecordContext {
+  account: Account
+  modelId: string
+  isInternal: boolean
+  tStart: number
+}
+
+function feedFrame(
+  rawEvent: { data?: string },
+  accumulator: StreamUsageAccumulator,
+): string | undefined {
+  if (!rawEvent.data || rawEvent.data === "[DONE]") return undefined
+  try {
+    const parsed = JSON.parse(rawEvent.data) as {
+      id?: string
+      usage?: unknown
+    }
+    accumulator.feed(parsed)
+    return parsed.id
+  } catch {
+    return undefined
+  }
+}
+
+function finalizeStreamUsage(
+  accumulator: StreamUsageAccumulator,
+  status: "ok" | "error" | "aborted",
+): { usage: NormalizedUsage; status: "ok" | "error" | "aborted" } {
+  try {
+    return { usage: accumulator.finalize(), status }
+  } catch (err) {
+    if (err instanceof UsageMissingError) {
+      consola.warn(
+        "Streaming completed without an include_usage frame; recording zero usage",
+      )
+    } else {
+      consola.error("Failed to finalize stream usage:", err)
+    }
+    return {
+      usage: ZERO_USAGE,
+      status: status === "ok" ? "error" : status,
+    }
+  }
+}
+
+function streamAndRecord(
+  c: Context,
+  response: AsyncIterable<{ data?: string }>,
+  ctx: RecordContext,
+) {
+  return streamSSE(c, async (stream) => {
+    const accumulator = createOpenAIAccumulator()
+    let status: "ok" | "error" | "aborted" = "ok"
+    let lastRequestId: string | undefined
+    try {
+      for await (const rawEvent of response) {
+        if (c.req.raw.signal.aborted) {
+          status = "aborted"
+          break
+        }
+        const id = feedFrame(rawEvent, accumulator)
+        if (id) lastRequestId = id
+        consola.debug("Streaming chunk:", JSON.stringify(rawEvent))
+        await stream.writeSSE(rawEvent as SSEMessage)
+      }
+    } catch (err) {
+      status = "error"
+      consola.error("Streaming chat-completions error:", err)
+    }
+
+    const result = finalizeStreamUsage(accumulator, status)
+    recordUsage({
+      account: ctx.account,
+      modelId: ctx.modelId,
+      endpoint: "chat.completions",
+      upstreamFormat: "openai",
+      isStreaming: true,
+      usage: result.usage,
+      durationMs: Date.now() - ctx.tStart,
+      status: result.status,
+      requestId: lastRequestId,
+      isInternal: ctx.isInternal,
+    })
+  })
 }
 
 export async function handleCompletion(c: Context) {
@@ -112,11 +201,19 @@ export async function handleCompletion(c: Context) {
   }
 
   consola.debug("Streaming response")
-  return streamSSE(c, async (stream) => {
-    for await (const chunk of response) {
-      consola.debug("Streaming chunk:", JSON.stringify(chunk))
-      await stream.writeSSE(chunk as SSEMessage)
-    }
+  if (!usedAccount) {
+    // Should never happen — withAccount always invokes the callback.
+    return streamSSE(c, async (stream) => {
+      for await (const chunk of response) {
+        await stream.writeSSE(chunk as SSEMessage)
+      }
+    })
+  }
+  return streamAndRecord(c, response, {
+    account: usedAccount,
+    modelId: payload.model,
+    isInternal,
+    tStart,
   })
 }
 

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -12,14 +12,31 @@ export const createChatCompletions = async (
 ) => {
   if (!ctx.account.copilotToken) throw new Error("Copilot token not found")
 
-  const enableVision = payload.messages.some(
+  // For streaming requests, force `stream_options.include_usage = true` so
+  // the upstream emits a final usage frame we can record. Some clients send
+  // `include_usage: false` explicitly — override anyway and log at debug.
+  let outgoing = payload
+  if (payload.stream) {
+    const existing = payload.stream_options ?? {}
+    if (existing.include_usage !== true) {
+      consola.debug(
+        "Forcing stream_options.include_usage=true for usage tracking",
+      )
+    }
+    outgoing = {
+      ...payload,
+      stream_options: { ...existing, include_usage: true },
+    }
+  }
+
+  const enableVision = outgoing.messages.some(
     (x) =>
       typeof x.content !== "string"
       && x.content?.some((x) => x.type === "image_url"),
   )
 
   // Agent/user check for X-Initiator header
-  const isAgentCall = payload.messages.some((msg) =>
+  const isAgentCall = outgoing.messages.some((msg) =>
     ["assistant", "tool"].includes(msg.role),
   )
 
@@ -31,7 +48,7 @@ export const createChatCompletions = async (
   const response = await fetch(`${copilotBaseUrl(ctx)}/chat/completions`, {
     method: "POST",
     headers,
-    body: JSON.stringify(payload),
+    body: JSON.stringify(outgoing),
   })
 
   if (!response.ok) {
@@ -39,7 +56,7 @@ export const createChatCompletions = async (
     throw new HTTPError("Failed to create chat completions", response)
   }
 
-  if (payload.stream) {
+  if (outgoing.stream) {
     return events(response)
   }
 
@@ -133,6 +150,7 @@ export interface ChatCompletionsPayload {
   stop?: string | Array<string> | null
   n?: number | null
   stream?: boolean | null
+  stream_options?: { include_usage?: boolean } | null
 
   frequency_penalty?: number | null
   presence_penalty?: number | null


### PR DESCRIPTION
Forces include_usage on streaming requests; records usage on stream close (ok/aborted/error).

Refs #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)